### PR TITLE
Conflicts the category package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     "contao/core": ">=3.1,<4",
     "psi/news4ward": "~2"
   },
+  "conflict": {
+    "psi/news4ward_categories": "*"
+  },
   "extra": {
     "contao": {
       "sources": {


### PR DESCRIPTION
If the categories package is installed, the category selection will appear twice in the backend.
